### PR TITLE
Ebs

### DIFF
--- a/automation/detach-ebs/detach-ebs-api-2.yml
+++ b/automation/detach-ebs/detach-ebs-api-2.yml
@@ -1,5 +1,5 @@
 ---
-description: Detach non-root ebs volume from instance without stopping it (describe volume API)
+description: Detach the volume only if the ec2 instance has the specified tags (using describes-volume API)
 schemaVersion: '0.3'
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:

--- a/automation/detach-ebs/detach-ebs-api-2.yml
+++ b/automation/detach-ebs/detach-ebs-api-2.yml
@@ -1,5 +1,5 @@
 ---
-description: Detach non-root ebs volume from instance without stopping it (describe instance api)
+description: Detach non-root ebs volume from instance without stopping it (describe volume API)
 schemaVersion: '0.3'
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:
@@ -17,21 +17,23 @@ parameters:
     description: "(Optional) The ARN of the role that allows Automation to perform
       the actions on your behalf."
 mainSteps:
-- name: listInstances
+- name: describeVolume
   action: aws:executeAwsApi
   timeoutSeconds: 60
   onFailure: Abort
   inputs:
     Service: ec2
-    Api: DescribeInstances
+    Api: DescribeVolumes
+    VolumeIds: ["{{ VolumeId }}"]
     Filters:
-    -  Name: block-device-mapping.volume-id
-       Values: ["{{ VolumeId }}"]
     -  Name: tag:{{ TagName }}
        Values: ["{{ TagValue }}"]
   outputs:
     - Name: InstanceId
-      Selector: "$.Reservations[0].Instances[0].InstanceId"
+      Selector: "$.Volumes[0].Attachments[0].InstanceId"
+      Type: String
+    - Name: DeviceType
+      Selector: "$.Volumes[0].Attachments[0].Device"
       Type: String
 - name: detachEbsVolume
   action: aws:executeAwsApi
@@ -41,7 +43,7 @@ mainSteps:
     Service: ec2
     Api: DetachVolume
     VolumeId: "{{ VolumeId }}"
-    InstanceId: "{{ listInstances.InstanceId }}"
+    InstanceId: "{{ describeVolume.InstanceId }}"
   outputs:
     - Name: EbsState
       Selector: "$.State"
@@ -68,6 +70,6 @@ mainSteps:
     - "{{ VolumeId }}"
     Tags:
     - Key: chaosAction
-      Value: Detachedfrom"{{ listInstances.InstanceId }}"
+      Value: Detachedfrom"{{ describeVolume.InstanceId }}"ofType{{ describeVolume.DeviceType }}
 outputs:
-- "listInstances.InstanceId"
+- "describeVolume.InstanceId"

--- a/automation/detach-ebs/detach-ebs-api.yml
+++ b/automation/detach-ebs/detach-ebs-api.yml
@@ -1,5 +1,5 @@
 ---
-description: Stop random EC2 instance in particular AZ, detach its ebs volume(s), and restart instance.
+description: Select random EC2 instance in AZ, tag and detach its ebs volume, and stop the instance.
 schemaVersion: '0.3'
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:

--- a/automation/detach-ebs/detach-ebs-api.yml
+++ b/automation/detach-ebs/detach-ebs-api.yml
@@ -1,11 +1,11 @@
 ---
-description: Select random EC2 instance in AZ, tag and detach its ebs volume, and stop the instance.
+description: Detach  non-root ebs volume from instance without stopping it
 schemaVersion: '0.3'
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:
-  AvailabilityZone:
+  VolumeId:
     type: String
-    description: "The Availability Zone to impact (Required) "
+    description: "The Ebs volume Id to detach (Required) "
   TagName:
     type: String
     description: "The tag name to filter instances"
@@ -25,84 +25,14 @@ mainSteps:
     Service: ec2
     Api: DescribeInstances
     Filters:
-    -  Name: availability-zone
-       Values: ["{{ AvailabilityZone }}"]
-    -  Name: instance-state-name
-       Values: ["running"]
+    -  Name: block-device-mapping.volume-id
+       Values: ["{{ VolumeId }}"]
     -  Name: tag:{{ TagName }}
        Values: ["{{ TagValue }}"]
   outputs:
-    - Name: InstanceIds
-      Selector: "$.Reservations..Instances..InstanceId"
-      Type: StringList
-- name: SeletRandomInstance
-  action: aws:executeScript
-  timeoutSeconds: 60
-  maxAttempts: 1
-  onFailure: Abort
-  inputs:
-    Runtime: python3.6
-    Handler: getRandomInstance
-    InputPayload:
-      InstanceIds:
-        - "{{ listInstances.InstanceIds }}"
-    Script: |-
-      def getRandomInstance(events, context):
-         import random
-         InstanceId = random.choice(events['InstanceIds'])
-         return { 'InstanceId' : InstanceId }
-  outputs:
     - Name: InstanceId
-      Selector: $.Payload.InstanceId
+      Selector: "$.Reservations[0].Instances[0].InstanceId"
       Type: String
-- name: describeInstance
-  action: aws:executeAwsApi
-  timeoutSeconds: 60
-  maxAttempts: 1
-  onFailure: Abort
-  inputs:
-    Service: ec2
-    Api: DescribeInstances
-    InstanceIds: 
-      - "{{ SeletRandomInstance.InstanceId }}"
-    Filters:
-      -  Name: instance-state-name
-         Values: ["running"]
-      -  Name: tag:{{ TagName }}
-         Values: ["{{ TagValue }}"]
-  outputs:
-    - Name: EbsId
-      Selector: "$.Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId"
-      Type: String
-- name: createTags
-  action: aws:createTags
-  maxAttempts: 2
-  timeoutSeconds: 60
-  onFailure: Abort
-  inputs:
-    ResourceType: EC2
-    ResourceIds:
-    - "{{ describeInstance.EbsId }}"
-    Tags:
-    - Key: chaosAction
-      Value: Detachedfrom"{{ SeletRandomInstance.InstanceId }}"
-- name: stopInstances
-  action: aws:changeInstanceState
-  timeoutSeconds: 60
-  onFailure: Continue
-  inputs:
-    InstanceIds: 
-      - "{{ SeletRandomInstance.InstanceId }}"
-    DesiredState: stopped
-- name: forceStopInstances
-  action: aws:changeInstanceState
-  timeoutSeconds: 60
-  inputs:
-    InstanceIds: 
-      - "{{ SeletRandomInstance.InstanceId }}"
-    CheckStateOnly: false
-    DesiredState: stopped
-    Force: true
 - name: detachEbsVolume
   action: aws:executeAwsApi
   timeoutSeconds: 60
@@ -110,8 +40,8 @@ mainSteps:
   inputs:
     Service: ec2
     Api: DetachVolume
-    VolumeId: "{{ describeInstance.EbsId }}"
-    InstanceId: "{{ SeletRandomInstance.InstanceId }}"
+    VolumeId: "{{ VolumeId }}"
+    InstanceId: "{{ listInstances.InstanceId }}"
   outputs:
     - Name: EbsState
       Selector: "$.State"
@@ -123,10 +53,21 @@ mainSteps:
     Service: ec2
     Api: DescribeVolumes
     VolumeIds:
-    - "{{ describeInstance.EbsId }}"
+    - "{{ VolumeId }}"
     PropertySelector: "$.Volumes[0].State"
     DesiredValues:
     - "available"
+- name: createTags
+  action: aws:createTags
+  maxAttempts: 2
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    ResourceType: EC2
+    ResourceIds:
+    - "{{ VolumeId }}"
+    Tags:
+    - Key: chaosAction
+      Value: Detachedfrom"{{ listInstances.InstanceId }}"
 outputs:
-- "describeInstance.EbsId"
-- "SeletRandomInstance.InstanceId"
+- "listInstances.InstanceId"

--- a/automation/detach-ebs/detach-ebs-api.yml
+++ b/automation/detach-ebs/detach-ebs-api.yml
@@ -1,5 +1,5 @@
 ---
-description: Detach non-root ebs volume from instance without stopping it (describe instance api)
+description: Detach the volume only if the ec2 instance has the specified tags (describe-instances api)
 schemaVersion: '0.3'
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:

--- a/automation/detach-ebs/detach-ebs-api.yml
+++ b/automation/detach-ebs/detach-ebs-api.yml
@@ -1,0 +1,132 @@
+---
+description: Stop random EC2 instance in particular AZ, detach its ebs volume(s), and restart instance.
+schemaVersion: '0.3'
+assumeRole: "{{ AutomationAssumeRole }}"
+parameters:
+  AvailabilityZone:
+    type: String
+    description: "The Availability Zone to impact (Required) "
+  TagName:
+    type: String
+    description: "The tag name to filter instances"
+  TagValue:
+    type: String
+    description: "The tag value to filter instances"
+  AutomationAssumeRole:
+    type: String
+    description: "(Optional) The ARN of the role that allows Automation to perform
+      the actions on your behalf."
+mainSteps:
+- name: listInstances
+  action: aws:executeAwsApi
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    Service: ec2
+    Api: DescribeInstances
+    Filters:
+    -  Name: availability-zone
+       Values: ["{{ AvailabilityZone }}"]
+    -  Name: instance-state-name
+       Values: ["running"]
+    -  Name: tag:{{ TagName }}
+       Values: ["{{ TagValue }}"]
+  outputs:
+    - Name: InstanceIds
+      Selector: "$.Reservations..Instances..InstanceId"
+      Type: StringList
+- name: SeletRandomInstance
+  action: aws:executeScript
+  timeoutSeconds: 60
+  maxAttempts: 1
+  onFailure: Abort
+  inputs:
+    Runtime: python3.6
+    Handler: getRandomInstance
+    InputPayload:
+      InstanceIds:
+        - "{{ listInstances.InstanceIds }}"
+    Script: |-
+      def getRandomInstance(events, context):
+         import random
+         InstanceId = random.choice(events['InstanceIds'])
+         return { 'InstanceId' : InstanceId }
+  outputs:
+    - Name: InstanceId
+      Selector: $.Payload.InstanceId
+      Type: String
+- name: describeInstance
+  action: aws:executeAwsApi
+  timeoutSeconds: 60
+  maxAttempts: 1
+  onFailure: Abort
+  inputs:
+    Service: ec2
+    Api: DescribeInstances
+    InstanceIds: 
+      - "{{ SeletRandomInstance.InstanceId }}"
+    Filters:
+      -  Name: instance-state-name
+         Values: ["running"]
+      -  Name: tag:{{ TagName }}
+         Values: ["{{ TagValue }}"]
+  outputs:
+    - Name: EbsId
+      Selector: "$.Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId"
+      Type: String
+- name: createTags
+  action: aws:createTags
+  maxAttempts: 2
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    ResourceType: EC2
+    ResourceIds:
+    - "{{ describeInstance.EbsId }}"
+    Tags:
+    - Key: chaosAction
+      Value: Detachedfrom"{{ SeletRandomInstance.InstanceId }}"
+- name: stopInstances
+  action: aws:changeInstanceState
+  timeoutSeconds: 60
+  onFailure: Continue
+  inputs:
+    InstanceIds: 
+      - "{{ SeletRandomInstance.InstanceId }}"
+    DesiredState: stopped
+- name: forceStopInstances
+  action: aws:changeInstanceState
+  timeoutSeconds: 60
+  inputs:
+    InstanceIds: 
+      - "{{ SeletRandomInstance.InstanceId }}"
+    CheckStateOnly: false
+    DesiredState: stopped
+    Force: true
+- name: detachEbsVolume
+  action: aws:executeAwsApi
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    Service: ec2
+    Api: DetachVolume
+    VolumeId: "{{ describeInstance.EbsId }}"
+    InstanceId: "{{ SeletRandomInstance.InstanceId }}"
+  outputs:
+    - Name: EbsState
+      Selector: "$.State"
+      Type: String
+- name: verifyRootVolumeDetached
+  action: aws:waitForAwsResourceProperty
+  timeoutSeconds: 30
+  inputs:
+    Service: ec2
+    Api: DescribeVolumes
+    VolumeIds:
+    - "{{ describeInstance.EbsId }}"
+    PropertySelector: "$.Volumes[0].State"
+    DesiredValues:
+    - "available"
+outputs:
+- "describeInstance.EbsId"
+- "SeletRandomInstance.InstanceId"

--- a/automation/detach-ebs/detach-root-ebs-api.yml
+++ b/automation/detach-ebs/detach-root-ebs-api.yml
@@ -1,0 +1,132 @@
+---
+description: Select random EC2 instance in AZ, tag and detach its ebs root volume, and stop the instance.
+schemaVersion: '0.3'
+assumeRole: "{{ AutomationAssumeRole }}"
+parameters:
+  AvailabilityZone:
+    type: String
+    description: "The Availability Zone to impact (Required) "
+  TagName:
+    type: String
+    description: "The tag name to filter instances"
+  TagValue:
+    type: String
+    description: "The tag value to filter instances"
+  AutomationAssumeRole:
+    type: String
+    description: "(Optional) The ARN of the role that allows Automation to perform
+      the actions on your behalf."
+mainSteps:
+- name: listInstances
+  action: aws:executeAwsApi
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    Service: ec2
+    Api: DescribeInstances
+    Filters:
+    -  Name: availability-zone
+       Values: ["{{ AvailabilityZone }}"]
+    -  Name: instance-state-name
+       Values: ["running"]
+    -  Name: tag:{{ TagName }}
+       Values: ["{{ TagValue }}"]
+  outputs:
+    - Name: InstanceIds
+      Selector: "$.Reservations..Instances..InstanceId"
+      Type: StringList
+- name: SeletRandomInstance
+  action: aws:executeScript
+  timeoutSeconds: 60
+  maxAttempts: 1
+  onFailure: Abort
+  inputs:
+    Runtime: python3.6
+    Handler: getRandomInstance
+    InputPayload:
+      InstanceIds:
+        - "{{ listInstances.InstanceIds }}"
+    Script: |-
+      def getRandomInstance(events, context):
+         import random
+         InstanceId = random.choice(events['InstanceIds'])
+         return { 'InstanceId' : InstanceId }
+  outputs:
+    - Name: InstanceId
+      Selector: $.Payload.InstanceId
+      Type: String
+- name: describeInstance
+  action: aws:executeAwsApi
+  timeoutSeconds: 60
+  maxAttempts: 1
+  onFailure: Abort
+  inputs:
+    Service: ec2
+    Api: DescribeInstances
+    InstanceIds: 
+      - "{{ SeletRandomInstance.InstanceId }}"
+    Filters:
+      -  Name: instance-state-name
+         Values: ["running"]
+      -  Name: tag:{{ TagName }}
+         Values: ["{{ TagValue }}"]
+  outputs:
+    - Name: EbsId
+      Selector: "$.Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId"
+      Type: String
+- name: createTags
+  action: aws:createTags
+  maxAttempts: 2
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    ResourceType: EC2
+    ResourceIds:
+    - "{{ describeInstance.EbsId }}"
+    Tags:
+    - Key: chaosAction
+      Value: Detachedfrom"{{ SeletRandomInstance.InstanceId }}"
+- name: stopInstances
+  action: aws:changeInstanceState
+  timeoutSeconds: 60
+  onFailure: Continue
+  inputs:
+    InstanceIds: 
+      - "{{ SeletRandomInstance.InstanceId }}"
+    DesiredState: stopped
+- name: forceStopInstances
+  action: aws:changeInstanceState
+  timeoutSeconds: 60
+  inputs:
+    InstanceIds: 
+      - "{{ SeletRandomInstance.InstanceId }}"
+    CheckStateOnly: false
+    DesiredState: stopped
+    Force: true
+- name: detachEbsVolume
+  action: aws:executeAwsApi
+  timeoutSeconds: 60
+  onFailure: Abort
+  inputs:
+    Service: ec2
+    Api: DetachVolume
+    VolumeId: "{{ describeInstance.EbsId }}"
+    InstanceId: "{{ SeletRandomInstance.InstanceId }}"
+  outputs:
+    - Name: EbsState
+      Selector: "$.State"
+      Type: String
+- name: verifyRootVolumeDetached
+  action: aws:waitForAwsResourceProperty
+  timeoutSeconds: 30
+  inputs:
+    Service: ec2
+    Api: DescribeVolumes
+    VolumeIds:
+    - "{{ describeInstance.EbsId }}"
+    PropertySelector: "$.Volumes[0].State"
+    DesiredValues:
+    - "available"
+outputs:
+- "describeInstance.EbsId"
+- "SeletRandomInstance.InstanceId"

--- a/automation/detach-ebs/detach-root-ebs-api.yml
+++ b/automation/detach-ebs/detach-root-ebs-api.yml
@@ -1,5 +1,5 @@
 ---
-description: Select random EC2 instance in AZ, tag and detach its ebs root volume, and stop the instance.
+description: Select random EC2 instance in AZ, tag its ebs root volume, stop the instance, and detach the root volume
 schemaVersion: '0.3'
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:


### PR DESCRIPTION
Adding three documents to detach EBS volumes:
__without stopping EC2 instance
1 - Detach the (non-root) volume only if the ec2 instance has the specified tags (describe-instances api)
2 - Detach the (non-root) volume only if the ec2 instance has the specified tags (using describes-volume API)

_with stopping EC2 instance
3 - Select random EC2 instance in AZ, tag its ebs root volume, stop the instance, and detach the root volume

_ALL_:   adding tags to Ebs volumes once detached. 