### PR TITLE
Prerequisites

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,11 @@ To use SSM Run Command, please check `this link <https://medium.com/@adhorn/inje
 * Support for blackhole EC2 stress using ``blackhole-ec2-stress.yml``
 * Support for blackhole DNS stress using ``blackhole-dns-stress.yml``
 
+**Prerequisites**
+
+* `SSM Agent <https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-ssm-agent.html>`_ (Preinstalled on several Amazon Machine Images)
+* `stress-ng <https://wiki.ubuntu.com/Kernel/Reference/stress-ng>`_ (Preinstalled on several Amazon Machine Images)
+
 
 Upload one document at a time
 -----------------------------

--- a/run-command/README.rst
+++ b/run-command/README.rst
@@ -18,3 +18,8 @@ To learn how to use these SSM Documents - please check `this link <https://mediu
 * Support for blackhole DynamoDB stress using ``blackhole-dynamo-stress.yml``
 * Support for blackhole EC2 stress using ``blackhole-ec2-stress.yml``
 * Support for blackhole DNS stress using ``blackhole-dns-stress.yml``
+
+**Prerequisites**
+
+* `SSM Agent <https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-ssm-agent.html>`_ (Preinstalled on several Amazon Machine Images)
+* `stress-ng <https://wiki.ubuntu.com/Kernel/Reference/stress-ng>`_ (Preinstalled on several Amazon Machine Images)


### PR DESCRIPTION
Added prerequisites to make it clear that SSM Agent and stress-ng isn't always preinstalled.