### PR TITLE
Create CloudFormation template SSM Run Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# YAML files including generated CloudFormation templates
+*.yaml
+*.yml

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,18 @@ Upload all of the SSM Documents to the AWS region of your choice
 
     ./upload-document.sh -r eu-west-1 (or other region of your choice)
 
+Upload all of the SSM Documents using CloudFormation
+----------------------------------------------------
+
+.. code:: shell
+
+    cd chaos-ssm-documents/
+
+    run-command/create-cfn.sh run-command/ | tee cfn-chaos-ssm.yml
+
+    aws cloudformation create-stack --stack-name ChaosSsm --template-body file://cfn-chaos-ssm.yml
+
+Specify AWS region using AWS CLI --region argument.
 
 SOME WORDS OF CAUTION BEFORE YOU START BREAKING THINGS:
 -------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,9 @@ Upload all of the SSM Documents using CloudFormation
 
 Specify AWS region using AWS CLI --region argument.
 
+Once deployed, the stack cannot be updated.
+Remove existing stack and re-deploy to apply changes.
+
 SOME WORDS OF CAUTION BEFORE YOU START BREAKING THINGS:
 -------------------------------------------------------
 

--- a/run-command/create-cfn.sh
+++ b/run-command/create-cfn.sh
@@ -15,11 +15,15 @@
 #
 # Do not pipe CloudFormation template file to run-command/ directory to avoid an endless loop.
 
-set -e
-
 [ -d "$1" ] || (echo "$0: usage: $0 /path/to/run-command/" >&2 && exit 1)
 
+head=$(git rev-parse HEAD)
+
+set -e
+
 cat <<EOF
+# https://github.com/adhorn/chaos-ssm-documents
+# $head
 AWSTemplateFormatVersion: 2010-09-09
 
 Description: |

--- a/run-command/create-cfn.sh
+++ b/run-command/create-cfn.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Create CloudFormation template with SSM Run Commands in the repository.
+# Reads YAML files from input path specified in first argument.
+# Command expects the input path contains SSM Run Command documents.
+# Outputs CloudFormation YAML template with all the SSM Run Commands.
+#
+# Usage:
+# $ run-command/create-cfn.sh run-command/ | tee cfn-chaos-ssm.yml
+# $ aws cloudformation create-stack --stack-name ChaosSsm --template-body file://cfn-chaos-ssm.yml
+#
+# Do not pipe CloudFormation template file to run-command/ directory to avoid an endless loop.
+
+set -e
+
+[ -d "$1" ] || (echo "$0: usage: $0 /path/to/run-command/" >&2 && exit 1)
+
+cat <<EOF
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: |
+  Chaos Injection for AWS resources using Amazon SSM Run Command and Automation
+
+Resources:
+EOF
+
+for document in "$1"/*.yml ; do
+    file=$(basename "$document")
+    resource=$(echo "$file" | sed -r 's/(^|-)([a-z])/\U\2/g' | cut -f1 -d.)
+    cat <<EOF
+
+  # $file
+  $resource:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Command
+      Content:
+EOF
+    sed -e '1d' -e 's/^/        /' < "$document"
+    echo ""
+done

--- a/run-command/create-cfn.sh
+++ b/run-command/create-cfn.sh
@@ -10,6 +10,9 @@
 # $ run-command/create-cfn.sh run-command/ | tee cfn-chaos-ssm.yml
 # $ aws cloudformation create-stack --stack-name ChaosSsm --template-body file://cfn-chaos-ssm.yml
 #
+# Resulting stack cannot be updated by using aws cloudformation update-stack
+# To update, first delete existing stack and then re-create it as above.
+#
 # Do not pipe CloudFormation template file to run-command/ directory to avoid an endless loop.
 
 set -e

--- a/run-command/create-cfn.sh
+++ b/run-command/create-cfn.sh
@@ -34,6 +34,7 @@ for document in "$1"/*.yml ; do
   $resource:
     Type: AWS::SSM::Document
     Properties:
+      Name: !Sub \${AWS::StackName}-$resource
       DocumentType: Command
       Content:
 EOF

--- a/run-command/create-cfn.sh
+++ b/run-command/create-cfn.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #
-# Create CloudFormation template with SSM Run Commands in the repository.
-# Reads YAML files from input path specified in first argument.
-# Command expects the input path contains SSM Run Command documents.
-# Outputs CloudFormation YAML template with all the SSM Run Commands.
+# Create CloudFormation template from SSM Run Command documents in directory.
+#
+#  - Reads YAML files from input path specified in first argument.
+#  - Command expects the input path contains SSM Run Command documents.
+#  - Outputs CloudFormation YAML template with all the SSM Run Commands.
 #
 # Usage:
 # $ run-command/create-cfn.sh run-command/ | tee cfn-chaos-ssm.yml

--- a/run-command/create-cfn.sh
+++ b/run-command/create-cfn.sh
@@ -27,7 +27,7 @@ EOF
 
 for document in "$1"/*.yml ; do
     file=$(basename "$document")
-    resource=$(echo "$file" | sed -r 's/(^|-)([a-z])/\U\2/g' | cut -f1 -d.)
+    resource=$(echo "$file" | cut -f1 -d. | perl -pe 's/([a-z0-9]+)|./\u$1/g')
     cat <<EOF
 
   # $file


### PR DESCRIPTION
Upload all of the SSM Documents using CloudFormation template created from the SSM Run Document files.

 - Reads YAML files from input path specified in first argument.
 - Command expects the input path contains SSM Run Command documents.
 - Outputs CloudFormation YAML template with all the SSM Run Commands.

Example usage:

```
$ cd chaos-ssm-documents/
$ run-command/create-cfn.sh run-command/ | tee cfn-chaos-ssm.yml
$ aws cloudformation create-stack --stack-name ChaosSsm --template-body file://cfn-chaos-ssm.yml
```

Benefit over `upload-document.sh` is being able to clean and update the run documents more easily, and to deploy them using Stack Sets.