### PR TITLE
Linux extras is required or stress-ng install fails

### DIFF
--- a/run-command/install-dependencies.yml
+++ b/run-command/install-dependencies.yml
@@ -6,4 +6,5 @@ mainSteps:
   name: InstallDependencies
   inputs:
     runCommand:
+    - "sudo amazon-linux-extras install testing"
     - "sudo yum -y install stress-ng tc jq htop"


### PR DESCRIPTION
It looks like this was included in the attacks themselves (e.g. see https://github.com/jyee/chaos-ssm-documents/blob/master/run-command/cpu-stress.yml#L30), but not updated here.

Without the testing tools, yum will not install stress-ng and will return `No package stress-ng available.`