### PR TITLE
Support for Amazon Linux 2023

### DIFF
--- a/run-command/blackhole-stress.yml
+++ b/run-command/blackhole-stress.yml
@@ -74,7 +74,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install iptables at
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             yum -y install iptables at
           else
             echo "There was a problem installing dependencies."

--- a/run-command/cpu-stress.yml
+++ b/run-command/cpu-stress.yml
@@ -65,7 +65,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install stress-ng
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             # Use amazon-linux-extras if available (Amazon Linux 2). Don't need it otherwise (Amazon Linux 1)
             which amazon-linux-extras 2>/dev/null 1>&2 && sudo amazon-linux-extras install testing
             sudo yum -y install stress-ng

--- a/run-command/diskspace-stress.yml
+++ b/run-command/diskspace-stress.yml
@@ -65,7 +65,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install stress-ng
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             # Use amazon-linux-extras if available (Amazon Linux 2). Don't need it otherwise (Amazon Linux 1)
             which amazon-linux-extras 2>/dev/null 1>&2 && sudo amazon-linux-extras install testing
             sudo yum -y install stress-ng

--- a/run-command/io-stress.yml
+++ b/run-command/io-stress.yml
@@ -65,7 +65,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install stress-ng
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             # Use amazon-linux-extras if available (Amazon Linux 2). Don't need it otherwise (Amazon Linux 1)
             which amazon-linux-extras 2>/dev/null 1>&2 && sudo amazon-linux-extras install testing
             sudo yum -y install stress-ng

--- a/run-command/latency-stress-sources.yml
+++ b/run-command/latency-stress-sources.yml
@@ -106,7 +106,7 @@ mainSteps:
         fi
       else
         echo "Dependencies are not installed - Please set InstallDependencies to True."
-        #exit 1
+        exit 1
       fi
 - action: aws:runShellScript
   name: FaultInjection

--- a/run-command/latency-stress-sources.yml
+++ b/run-command/latency-stress-sources.yml
@@ -90,6 +90,7 @@ mainSteps:
         if [ -f  "/etc/system-release" ] ; then
           if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
             sudo dnf -y install iproute-tc jq at
+            sudo dnf -y install bind-utils
           elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc jq at

--- a/run-command/latency-stress-sources.yml
+++ b/run-command/latency-stress-sources.yml
@@ -95,7 +95,7 @@ mainSteps:
             sudo yum -y install tc jq at
           else
             echo "There was a problem installing dependencies."
-            #exit 1
+            exit 1
           fi
         elif cat /etc/issue | grep -i Ubuntu ; then
           sudo apt-get update -y

--- a/run-command/latency-stress-sources.yml
+++ b/run-command/latency-stress-sources.yml
@@ -88,12 +88,14 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install iproute-tc jq at
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc jq at
           else
             echo "There was a problem installing dependencies."
-            exit 1
+            #exit 1
           fi
         elif cat /etc/issue | grep -i Ubuntu ; then
           sudo apt-get update -y
@@ -104,7 +106,7 @@ mainSteps:
         fi
       else
         echo "Dependencies are not installed - Please set InstallDependencies to True."
-        exit 1
+        #exit 1
       fi
 - action: aws:runShellScript
   name: FaultInjection

--- a/run-command/latency-stress.yml
+++ b/run-command/latency-stress.yml
@@ -66,7 +66,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install iproute-tc jq at
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc at
           else

--- a/run-command/latency-stress.yml
+++ b/run-command/latency-stress.yml
@@ -68,6 +68,7 @@ mainSteps:
         if [ -f  "/etc/system-release" ] ; then
           if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
             sudo dnf -y install iproute-tc jq at
+            sudo dnf -y install bind-utils
           elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc at

--- a/run-command/memory-stress.yml
+++ b/run-command/memory-stress.yml
@@ -64,7 +64,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install stress-ng
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             # Use amazon-linux-extras if available (Amazon Linux 2). Don't need it otherwise (Amazon Linux 1)
             which amazon-linux-extras 2>/dev/null 1>&2 && sudo amazon-linux-extras install testing
             sudo yum -y install stress-ng

--- a/run-command/network-loss-stress-sources.yml
+++ b/run-command/network-loss-stress-sources.yml
@@ -84,6 +84,7 @@ mainSteps:
         if [ -f  "/etc/system-release" ] ; then
           if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
             sudo dnf -y install iproute-tc jq a
+            sudo dnf -y install bind-utils
           elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc jq at

--- a/run-command/network-loss-stress-sources.yml
+++ b/run-command/network-loss-stress-sources.yml
@@ -82,7 +82,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install iproute-tc jq a
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc jq at
           else

--- a/run-command/network-loss-stress.yml
+++ b/run-command/network-loss-stress.yml
@@ -67,7 +67,8 @@ mainSteps:
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
           if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
-            sudo dnf -y install iproute-tc at        
+            sudo dnf -y install iproute-tc at
+            sudo dnf -y install bind-utils
           elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc at

--- a/run-command/network-loss-stress.yml
+++ b/run-command/network-loss-stress.yml
@@ -66,7 +66,9 @@ mainSteps:
       if  [[ "{{ InstallDependencies }}" == True ]] ; then
         echo "Installing required dependencies"
         if [ -f  "/etc/system-release" ] ; then
-          if cat /etc/system-release | grep -i 'Amazon Linux' ; then
+          if cat /etc/system-release | grep -i 'Amazon Linux release 2023' ; then
+            sudo dnf -y install iproute-tc at        
+          elif cat /etc/system-release | grep -i 'Amazon Linux' ; then
             sudo amazon-linux-extras install testing
             sudo yum -y install tc at
           else


### PR DESCRIPTION
Adds support for Amazon Linux 2023:

- Doesn't use `amazon-linux-extras` as these no longer exist for AL23
- Installs `tc` via `iproute-tc` package
- Uses `dnf` instead of `yum`